### PR TITLE
Do not filter file types in file picker

### DIFF
--- a/app/src/main/java/protect/videotranscoder/activity/MainActivity.java
+++ b/app/src/main/java/protect/videotranscoder/activity/MainActivity.java
@@ -340,19 +340,12 @@ public class MainActivity extends AppCompatActivity
      */
     private void selectVideo()
     {
-        ArrayList<String> extensions = new ArrayList<>();
-        for(MediaContainer item : MediaContainer.values())
-        {
-            extensions.add(item.extension);
-        }
-
         final StorageChooser fileChooser = new StorageChooser.Builder()
                 .withActivity(MainActivity.this)
                 .withFragmentManager(getFragmentManager())
                 .allowCustomPath(true)
                 .setType(StorageChooser.FILE_PICKER)
                 .disableMultiSelect()
-                .customFilter(extensions)
                 .build();
 
         // get path that the user has chosen


### PR DESCRIPTION
The filtering traverses all directories in the mentioned storage
folder first, then presents the results to the user. This
results in long delays between selecting the storage type
and seeing the file browser. In some cases an ANR results.