### PR TITLE
Add support for opus audio

### DIFF
--- a/app/src/main/java/protect/videotranscoder/media/AudioCodec.java
+++ b/app/src/main/java/protect/videotranscoder/media/AudioCodec.java
@@ -13,6 +13,7 @@ public enum AudioCodec
 {
     AAC("aac", Arrays.asList("1", "2")),
     MP3("mp3", Arrays.asList("1", "2")),
+    OPUS("libopus", Arrays.asList("1", "2")),
     VORBIS("vorbis", Collections.singletonList("2")),
     NONE("none", Collections.EMPTY_LIST),
     ;

--- a/app/src/main/java/protect/videotranscoder/media/MediaContainer.java
+++ b/app/src/main/java/protect/videotranscoder/media/MediaContainer.java
@@ -14,13 +14,14 @@ public enum MediaContainer
 {
     // Video and audio:
     FLV("flv", "flv", "video/x-flv", Collections.singletonList(VideoCodec.H264), Arrays.asList(AudioCodec.AAC, AudioCodec.MP3, AudioCodec.NONE)),
-    MKV("matroska", "mkv", "video/x-matroska", Arrays.asList(VideoCodec.H264, VideoCodec.MPEG4, VideoCodec.MPEG2, VideoCodec.MPEG1), Arrays.asList(AudioCodec.AAC, AudioCodec.MP3, AudioCodec.NONE)),
+    MKV("matroska", "mkv", "video/x-matroska", Arrays.asList(VideoCodec.H264, VideoCodec.MPEG4, VideoCodec.MPEG2, VideoCodec.MPEG1), Arrays.asList(AudioCodec.AAC, AudioCodec.MP3, AudioCodec.OPUS, AudioCodec.NONE)),
     MP4("mp4", "mp4", "video/mp4", Arrays.asList(VideoCodec.H264, VideoCodec.MPEG4, VideoCodec.MPEG2, VideoCodec.MPEG1), Arrays.asList(AudioCodec.AAC, AudioCodec.MP3, AudioCodec.NONE)),
     GIF("gif", "gif", "image/gif", Arrays.asList(VideoCodec.GIF), Collections.EMPTY_LIST),
 
     // Audio only
     MP3("mp3", "mp3", "audio/mp3", new ArrayList<VideoCodec>(), Collections.singletonList(AudioCodec.MP3)),
     OGG("ogg", "ogg", "audio/ogg", new ArrayList<VideoCodec>(), Arrays.asList(AudioCodec.VORBIS)),
+    OPUS("opus", "opus", "audio/ogg", new ArrayList<VideoCodec>(), Arrays.asList(AudioCodec.OPUS)),
     ;
 
     public final String ffmpegName;


### PR DESCRIPTION
Opus is supported in FFmpeg through the libopus codec.
There is a 'opus' codec but it is experimentally supported.
Additionally, MKV support for opus exists, but MP4 support
is experimental and is not being enabled.

https://github.com/brarcher/video-transcoder/issues/37