### PR TITLE
Use ACRA to capture crashes, easily send via email

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,11 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -33,12 +37,18 @@ android {
             includeAndroidResources = true
         }
     }
+
+    // ACRA depends on Java 8
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.android.support:design:27.0.2'
+    compile 'com.android.support:appcompat-v7:27.1.0'
+    compile 'com.android.support:design:27.1.0'
     implementation 'protect:android-ffmpeg:release@aar'
     compile 'com.crystal:crystalrangeseekbar:1.1.3'
     compile 'commons-io:commons-io:2.5'
@@ -46,6 +56,8 @@ dependencies {
     compile 'com.nononsenseapps:filepicker:4.2.1'
     implementation group: 'org.javatuples', name: 'javatuples', version: '1.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.8.11.1'
+
+    implementation 'ch.acra:acra:4.11'
 
     testCompile 'junit:junit:4.12'
     testCompile "org.robolectric:robolectric:3.6.1"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,45 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
+
+# This keep the class and method names the same, for debugging stack traces
+-dontobfuscate
+
+-dontwarn javax.annotation.**
+-dontwarn sun.misc.Unsafe
+
+# Android support library
+-keep class android.support.v4.** { *; }
+-keep interface android.support.v4.** { *; }
+-keep class android.support.v7.** { *; }
+-keep interface android.support.v7.** { *; }
+
+# Guava
+-dontwarn com.google.common.base.**
+-keep class com.google.common.base.** {*;}
+-dontwarn com.google.errorprone.annotations.**
+-keep class com.google.errorprone.annotations.** {*;}
+-dontwarn com.google.j2objc.annotations.**
+-keep class com.google.j2objc.annotations.** { *; }
+-dontwarn java.lang.ClassValue
+-keep class java.lang.ClassValue { *; }
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+-keep class org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement { *; }
+
+# Proguard configuration for Jackson 2.x (fasterxml package)
+-keep class com.fasterxml.jackson.databind.ObjectMapper {
+    public <methods>;
+    protected <methods>;
+}
+-keep class com.fasterxml.jackson.databind.ObjectWriter {
+    public ** writeValueAsString(**);
+}
+-keepnames class com.fasterxml.jackson.** { *; }
+-dontwarn com.fasterxml.jackson.databind.**
+
+# crystalrangeseekbar
+-keep class com.crystal.crystalrangeseekbar.** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <application
+        android:name=".App"
         android:allowBackup="false"
         tools:replace="android:allowBackup"
         android:icon="@mipmap/ic_launcher"
@@ -33,6 +34,10 @@
                 <action android:name="android.intent.action.GET_CONTENT" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".report.ErrorActivity"
+            android:label="@string/app_name">
         </activity>
         <provider
             android:name=".provider.ExportFileProvider"

--- a/app/src/main/java/protect/videotranscoder/App.java
+++ b/app/src/main/java/protect/videotranscoder/App.java
@@ -1,0 +1,43 @@
+package protect.videotranscoder;
+
+import android.app.Application;
+import android.content.Context;
+
+import org.acra.ACRA;
+import org.acra.config.ACRAConfiguration;
+import org.acra.config.ACRAConfigurationException;
+import org.acra.config.ConfigurationBuilder;
+import org.acra.sender.ReportSenderFactory;
+
+import protect.videotranscoder.report.AcraReportSenderFactory;
+import protect.videotranscoder.report.ErrorActivity;
+import protect.videotranscoder.report.UserAction;
+
+public class App extends Application
+{
+    private static final Class<? extends ReportSenderFactory>[] reportSenderFactoryClasses = new Class[]{AcraReportSenderFactory.class};
+
+    @Override
+    protected void attachBaseContext(Context base)
+    {
+        super.attachBaseContext(base);
+        initACRA();
+    }
+
+    private void initACRA()
+    {
+        try
+        {
+            final ACRAConfiguration acraConfig = new ConfigurationBuilder(this)
+                    .setReportSenderFactoryClasses(reportSenderFactoryClasses)
+                    .setBuildConfigClass(BuildConfig.class)
+                    .build();
+            ACRA.init(this, acraConfig);
+        }
+        catch (ACRAConfigurationException ace)
+        {
+            ErrorActivity.reportError(this, ace, null, ErrorActivity.ErrorInfo.make(UserAction.SOMETHING_ELSE, "none",
+                    "Could not initialize ACRA crash report", R.string.app_ui_crash));
+        }
+    }
+}

--- a/app/src/main/java/protect/videotranscoder/activity/MainActivity.java
+++ b/app/src/main/java/protect/videotranscoder/activity/MainActivity.java
@@ -1412,6 +1412,7 @@ public class MainActivity extends AppCompatActivity
             .put("NoNonsense-FilePicker", "https://github.com/spacecowboy/NoNonsense-FilePicker")
             .put("javatuples", "https://www.javatuples.org/")
             .put("jackson-databind", "https://github.com/FasterXML/jackson-databind")
+            .put("ACRA", "https://github.com/ACRA/acra")
             .build();
 
         final Map<String, String> USED_ASSETS = ImmutableMap.of

--- a/app/src/main/java/protect/videotranscoder/report/AcraReportSender.java
+++ b/app/src/main/java/protect/videotranscoder/report/AcraReportSender.java
@@ -1,0 +1,41 @@
+package protect.videotranscoder.report;
+
+/*
+ * Created by Christian Schabesberger  on 13.09.16.
+ *
+ * Copyright (C) Christian Schabesberger 2015 <chris.schabesberger@mailbox.org>
+ * AcraReportSender.java is originally part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import org.acra.collector.CrashReportData;
+import org.acra.sender.ReportSender;
+import org.acra.sender.ReportSenderException;
+
+import protect.videotranscoder.R;
+
+public class AcraReportSender implements ReportSender
+{
+    @Override
+    public void send(@NonNull Context context, @NonNull CrashReportData report) throws ReportSenderException
+    {
+        ErrorActivity.reportError(context, report,
+                ErrorActivity.ErrorInfo.make(UserAction.UI_ERROR,"none",
+                        "App crash, UI failure", R.string.app_ui_crash));
+    }
+}

--- a/app/src/main/java/protect/videotranscoder/report/AcraReportSenderFactory.java
+++ b/app/src/main/java/protect/videotranscoder/report/AcraReportSenderFactory.java
@@ -1,0 +1,37 @@
+package protect.videotranscoder.report;
+
+/*
+ * Created by Christian Schabesberger  on 13.09.16.
+ *
+ * Copyright (C) Christian Schabesberger 2015 <chris.schabesberger@mailbox.org>
+ * AcraReportSenderFactory.java is originally part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import org.acra.config.ACRAConfiguration;
+import org.acra.sender.ReportSender;
+import org.acra.sender.ReportSenderFactory;
+
+public class AcraReportSenderFactory implements ReportSenderFactory
+{
+    @NonNull
+    public ReportSender create(@NonNull Context context, @NonNull ACRAConfiguration config)
+    {
+        return new AcraReportSender();
+    }
+}

--- a/app/src/main/java/protect/videotranscoder/report/ErrorActivity.java
+++ b/app/src/main/java/protect/videotranscoder/report/ErrorActivity.java
@@ -1,0 +1,447 @@
+package protect.videotranscoder.report;
+
+/*
+ * Originally created by Christian Schabesberger on 24.10.15.
+ * Adapted by Branden Archer.
+ *
+ * Copyright (C) Christian Schabesberger 2016 <chris.schabesberger@mailbox.org>
+ * Copyright (C) Branden Archer 2018.
+ * ErrorActivity.java is originally part of NewPipe.
+ *
+ * NewPipe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <
+ * NewPipe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <
+ * You should have received a copy of the GNU General Public License
+ * along with NewPipe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Color;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.design.widget.Snackbar;
+import android.support.v4.app.NavUtils;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import org.acra.ReportField;
+import org.acra.collector.CrashReportData;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.Vector;
+
+import protect.videotranscoder.BuildConfig;
+import protect.videotranscoder.R;
+import protect.videotranscoder.activity.MainActivity;
+
+public class ErrorActivity extends AppCompatActivity
+{
+    // LOG TAGS
+    public static final String TAG = "VideoTranscoder";
+    // BUNDLE TAGS
+    public static final String ERROR_INFO = "error_info";
+    public static final String ERROR_LIST = "error_list";
+
+    public static final String ERROR_EMAIL_ADDRESS = "protect.github+" + TAG + "-" + BuildConfig.VERSION_NAME + "@gmail.com";
+    public static final String ERROR_EMAIL_SUBJECT = "Exception in " + TAG + " " + BuildConfig.VERSION_NAME;
+    private String[] errorList;
+    private ErrorInfo errorInfo;
+    private String currentTimeStamp;
+    // views
+    private EditText userCommentBox;
+
+    public static void reportUiError(final AppCompatActivity activity, final Throwable el)
+    {
+        reportError(activity, el, null,
+                ErrorInfo.make(UserAction.UI_ERROR, "none", "", R.string.app_ui_crash));
+    }
+
+    public static void reportError(final Context context, final List<Throwable> el,
+                                   View rootView, final ErrorInfo errorInfo)
+    {
+        if (rootView != null)
+        {
+            Snackbar.make(rootView, R.string.error_snackbar_message, 3 * 1000)
+                    .setActionTextColor(Color.YELLOW)
+                    .setAction(R.string.error_snackbar_action, v ->
+                            startErrorActivity(context, errorInfo, el)).show();
+        }
+        else
+        {
+            startErrorActivity(context, errorInfo, el);
+        }
+    }
+
+    private static void startErrorActivity(Context context, ErrorInfo errorInfo, List<Throwable> el)
+    {
+        Intent intent = new Intent(context, ErrorActivity.class);
+        intent.putExtra(ERROR_INFO, errorInfo);
+        intent.putExtra(ERROR_LIST, elToSl(el));
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+    }
+
+    public static void reportError(final Context context, final Throwable e,
+                                   View rootView, final ErrorInfo errorInfo)
+    {
+        List<Throwable> el = null;
+        if (e != null)
+        {
+            el = new Vector<>();
+            el.add(e);
+        }
+        reportError(context, el, rootView, errorInfo);
+    }
+
+    // async call
+    public static void reportError(Handler handler, final Context context, final Throwable e,
+                                   final View rootView, final ErrorInfo errorInfo)
+    {
+        List<Throwable> el = null;
+        if (e != null) {
+            el = new Vector<>();
+            el.add(e);
+        }
+        reportError(handler, context, el, rootView, errorInfo);
+    }
+
+    // async call
+    public static void reportError(Handler handler, final Context context, final List<Throwable> el,
+                                   final View rootView, final ErrorInfo errorInfo)
+    {
+        handler.post(() -> reportError(context, el, rootView, errorInfo));
+    }
+
+    public static void reportError(final Context context, final CrashReportData report, final ErrorInfo errorInfo)
+    {
+        // get key first (don't ask about this solution)
+        ReportField key = null;
+        for (ReportField k : report.keySet())
+        {
+            if (k.toString().equals("STACK_TRACE"))
+            {
+                key = k;
+            }
+        }
+        String[] el = new String[]{report.get(key).toString()};
+
+        Intent intent = new Intent(context, ErrorActivity.class);
+        intent.putExtra(ERROR_INFO, errorInfo);
+        intent.putExtra(ERROR_LIST, el);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+    }
+
+    private static String getStackTrace(final Throwable throwable)
+    {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter(sw, true);
+        throwable.printStackTrace(pw);
+        return sw.getBuffer().toString();
+    }
+
+    // errorList to StringList
+    private static String[] elToSl(List<Throwable> stackTraces)
+    {
+        String[] out = new String[stackTraces.size()];
+        for (int i = 0; i < stackTraces.size(); i++)
+        {
+            out[i] = getStackTrace(stackTraces.get(i));
+        }
+        return out;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_error);
+
+        Intent intent = getIntent();
+
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null)
+        {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle(R.string.error_report_title);
+            actionBar.setDisplayShowTitleEnabled(true);
+        }
+
+        Button reportButton = findViewById(R.id.errorReportButton);
+        userCommentBox = findViewById(R.id.errorCommentBox);
+        TextView errorView = findViewById(R.id.errorView);
+        TextView errorMessageView = findViewById(R.id.errorMessageView);
+
+        errorInfo = intent.getParcelableExtra(ERROR_INFO);
+        errorList = intent.getStringArrayExtra(ERROR_LIST);
+
+        currentTimeStamp = getCurrentTimeStamp();
+
+        reportButton.setOnClickListener((View v) ->
+        {
+            Intent i = new Intent(Intent.ACTION_SENDTO);
+            i.setData(Uri.parse("mailto:" + ERROR_EMAIL_ADDRESS))
+                    .putExtra(Intent.EXTRA_SUBJECT, ERROR_EMAIL_SUBJECT)
+                    .putExtra(Intent.EXTRA_TEXT, buildText());
+
+            startActivity(Intent.createChooser(i, getString(R.string.send_email_title)));
+        });
+
+        // normal bugreport
+        buildInfo(errorInfo);
+        if (errorInfo.message != 0)
+        {
+            errorMessageView.setText(errorInfo.message);
+        }
+        else
+        {
+            errorMessageView.setVisibility(View.GONE);
+            findViewById(R.id.messageWhatHappenedView).setVisibility(View.GONE);
+        }
+
+        errorView.setText(formErrorText(errorList));
+
+        // print stack trace once again for debugging:
+        for (String e : errorList)
+        {
+            Log.e(TAG, e);
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu)
+    {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.error_menu, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item)
+    {
+        int id = item.getItemId();
+
+        if(id == android.R.id.home)
+        {
+            goToReturnActivity();
+        }
+
+        if(id == R.id.menu_item_share_error)
+        {
+            Intent intent = new Intent();
+            intent.setAction(Intent.ACTION_SEND);
+            intent.putExtra(Intent.EXTRA_TEXT, buildText());
+            intent.setType("text/plain");
+            startActivity(Intent.createChooser(intent, getString(R.string.share_dialog_title)));
+        }
+
+        return false;
+    }
+
+    private String formErrorText(String[] el)
+    {
+        StringBuilder sb = new StringBuilder();
+        if (el != null)
+        {
+            for (String e : el)
+            {
+                sb.append("-------------------------------------\n");
+                sb.append(e);
+            }
+        }
+        sb.append("-------------------------------------");
+        return sb.toString();
+    }
+
+    /**
+     * Get the activity to return to
+     */
+    static Class<? extends Activity> getReturnActivity()
+    {
+        return MainActivity.class;
+    }
+
+    private void goToReturnActivity()
+    {
+        Class<? extends Activity> checkedReturnActivity = getReturnActivity();
+
+        Intent intent = new Intent(this, checkedReturnActivity);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        NavUtils.navigateUpTo(this, intent);
+    }
+
+    private void buildInfo(ErrorInfo info)
+    {
+        TextView infoLabelView = findViewById(R.id.errorInfoLabelsView);
+        TextView infoView = findViewById(R.id.errorInfosView);
+        String text = "";
+
+        infoLabelView.setText(getString(R.string.info_labels).replace("\\n", "\n"));
+
+        text += getUserActionString(info.userAction)
+                + "\n" + info.request
+                + "\n" + getContentLangString()
+                + "\n" + info.serviceName
+                + "\n" + currentTimeStamp
+                + "\n" + getPackageName()
+                + "\n" + BuildConfig.VERSION_NAME
+                + "\n" + getOsString();
+
+        infoView.setText(text);
+    }
+
+    private String buildText()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("user_action: ").append(getUserActionString(errorInfo.userAction)).append("\n");
+        sb.append("request: ").append(errorInfo.request).append("\n");
+        sb.append("content_language: ").append(getContentLangString()).append("\n");
+        sb.append("service: ").append(errorInfo.serviceName).append("\n");
+        sb.append("package: ").append(getPackageName()).append("\n");
+        sb.append("version: ").append(BuildConfig.VERSION_NAME).append("\n");
+        sb.append("os: ").append(getOsString()).append("\n");
+        sb.append("time: ").append(currentTimeStamp).append("\n");
+
+        sb.append("\nexceptions:\n");
+        if (errorList != null)
+        {
+            for (String e : errorList)
+            {
+                sb.append(e).append("\n");
+            }
+        }
+
+        sb.append("user_comment:\n").append(userCommentBox.getText().toString());
+
+        return sb.toString();
+
+    }
+
+    private String getUserActionString(UserAction userAction)
+    {
+        if (userAction == null)
+        {
+            return "Your description is in another castle.";
+        }
+        else
+        {
+            return userAction.getMessage();
+        }
+    }
+
+    private String getContentLangString()
+    {
+        return Locale.getDefault().getLanguage();
+    }
+
+    private String getOsString() {
+        String osBase = Build.VERSION.SDK_INT >= 23 ? Build.VERSION.BASE_OS : "Android";
+        return System.getProperty("os.name")
+                + " " + (osBase.isEmpty() ? "Android" : osBase)
+                + " " + Build.VERSION.RELEASE
+                + " - " + Integer.toString(Build.VERSION.SDK_INT);
+    }
+
+    @Override
+    public void onBackPressed() {
+        //super.onBackPressed();
+        goToReturnActivity();
+    }
+
+    public String getCurrentTimeStamp()
+    {
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US);
+        df.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return df.format(new Date());
+    }
+
+    public static class ErrorInfo implements Parcelable
+    {
+        public static final Parcelable.Creator<ErrorInfo> CREATOR = new Parcelable.Creator<ErrorInfo>()
+        {
+            @Override
+            public ErrorInfo createFromParcel(Parcel source)
+            {
+                return new ErrorInfo(source);
+            }
+
+            @Override
+            public ErrorInfo[] newArray(int size)
+            {
+                return new ErrorInfo[size];
+            }
+        };
+        final UserAction userAction;
+        final String request;
+        final String serviceName;
+        @StringRes
+        final int message;
+
+        private ErrorInfo(UserAction userAction, String serviceName, String request, @StringRes int message)
+        {
+            this.userAction = userAction;
+            this.serviceName = serviceName;
+            this.request = request;
+            this.message = message;
+        }
+
+        ErrorInfo(Parcel in)
+        {
+            this.userAction = UserAction.valueOf(in.readString());
+            this.request = in.readString();
+            this.serviceName = in.readString();
+            this.message = in.readInt();
+        }
+
+        public static ErrorInfo make(UserAction userAction, String serviceName, String request, @StringRes int message)
+        {
+            return new ErrorInfo(userAction, serviceName, request, message);
+        }
+
+        @Override
+        public int describeContents()
+        {
+            return 0;
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags)
+        {
+            dest.writeString(this.userAction.name());
+            dest.writeString(this.request);
+            dest.writeString(this.serviceName);
+            dest.writeInt(this.message);
+        }
+    }
+}

--- a/app/src/main/java/protect/videotranscoder/report/UserAction.java
+++ b/app/src/main/java/protect/videotranscoder/report/UserAction.java
@@ -1,0 +1,23 @@
+package protect.videotranscoder.report;
+
+/**
+ * The user actions that can cause an error.
+ */
+public enum UserAction {
+    USER_REPORT("user report"),
+    UI_ERROR("ui error"),
+    VIDEO_LOAD("video load"),
+    ENCODE("encode"),
+    SOMETHING_ELSE("something"),
+    ;
+
+    private final String message;
+
+    UserAction(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/app/src/main/res/layout/activity_error.xml
+++ b/app/src/main/res/layout/activity_error.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             tools:context=".report.ErrorActivity">
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/activity_vertical_margin"
+            android:paddingLeft="@dimen/activity_horizontal_margin"
+            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:paddingTop="@dimen/activity_vertical_margin"
+            android:focusable="true"
+            android:focusableInTouchMode="true">
+
+            <TextView
+                android:id="@+id/errorSorryView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceLarge"
+                android:gravity="center"
+                android:text="@string/sorry_string"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/messageWhatHappenedView"
+                android:paddingTop="@dimen/activity_vertical_margin"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:text="@string/what_happened_headline"/>
+
+            <TextView
+                android:id="@+id/errorMessageView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceMedium"/>
+
+            <TextView
+                android:id="@+id/errorDeviceHeadlineView"
+                android:paddingTop="@dimen/activity_vertical_margin"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:text="@string/what_device_headline"/>
+
+            <LinearLayout
+                android:id="@+id/errorInfoLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/errorInfoLabelsView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold"
+                    android:text="@string/info_labels"/>
+
+                <HorizontalScrollView
+                    android:paddingLeft="16dp"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/errorInfosView"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+
+                </HorizontalScrollView>
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/errorDetailView"
+                android:paddingTop="@dimen/activity_vertical_margin"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:text="@string/error_details_headline"/>
+
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/horizontalScrollView"
+                android:layout_gravity="center" >
+                <TextView
+                    android:id="@+id/errorView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:typeface="monospace"/>
+            </HorizontalScrollView>
+
+            <TextView
+                android:id="@+id/errorYourComment"
+                android:paddingTop="@dimen/activity_vertical_margin"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:text="@string/your_comment"/>
+
+            <EditText
+                android:id="@+id/errorCommentBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
+            <Button
+                android:id="@+id/errorReportButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/error_report_button_text" />
+
+        </LinearLayout>
+    </ScrollView>
+
+</FrameLayout>

--- a/app/src/main/res/menu/error_menu.xml
+++ b/app/src/main/res/menu/error_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:id="@+id/menu_item_share_error"
+          android:title="@string/share"
+          app:showAsAction="never"/>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
 
     <string name="ok">OK</string>
     <string name="sendLabel">Send&#8230;</string>
+    <string name="share_dialog_title">Share with</string>
+    <string name="share">Share</string>
 
     <string name="basicSettingsTitle">Basic Settings</string>
     <string name="container">Container</string>
@@ -54,4 +56,21 @@
     <string name="app_revision_fmt">Revision Information: <xliff:g id="app_revision_url">%s</xliff:g></string>
     <string name="app_libraries"><xliff:g id="app_name">%s</xliff:g> uses the following third-party libraries: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="app_resources"><xliff:g id="app_name">%s</xliff:g> uses the following third-party resources: <xliff:g id="app_resources_list">%s</xliff:g></string>
+
+    <!-- error strings -->
+    <string name="app_ui_crash">App/UI crashed</string>
+    <string name="send_email_title">Send Email</string>
+
+    <!-- error activity -->
+    <string name="sorry_string">Sorry, that should not have happened.</string>
+    <string name="error_report_button_text">Report error via e-mail</string>
+    <string name="error_snackbar_message">Sorry, some errors occurred.</string>
+    <string name="error_snackbar_action">REPORT</string>
+    <string name="what_device_headline">Info:</string>
+    <string name="what_happened_headline">What happened:</string>
+    <string name="info_labels">What:\\nRequest:\\nContent Lang:\\nService:\\nGMT Time:\\nPackage:\\nVersion:\\nOS version:</string>
+    <string name="your_comment">Your comment (in English):</string>
+    <string name="error_details_headline">Details:</string>
+    <string name="error_report_title">Error report</string>
+
 </resources>


### PR DESCRIPTION
A number of crashes have been recorded in Google Play, but
it is tricky to determine what is going on. The expectation is
that if crash logs can be captured by users directly, they
may contain more data. In addition, users may enter additional
details which may help track down issues. There will also be
the ability to contact the users for additional info.

Note that ProGuard was necessary, as inclduing ACRA resulted in
a apk which had more methods than the limit of 64k.