### PR TITLE
Set a notification channel for FFmpeg service

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,6 @@
     <string name="error_details_headline">Details:</string>
     <string name="error_report_title">Error report</string>
 
+    <string name="notificationChannelName">VideoTranscoder Encoding Service</string>
+
 </resources>


### PR DESCRIPTION
On Android 8.1 a notification channel is required for background
services. As one was not being created, a RemoteServiceException was
being thrown when encoding was attempted.

https://github.com/brarcher/video-transcoder/issues/80