### PR TITLE
Skip palette generation step when converting to gif

### DIFF
--- a/app/src/main/java/protect/videotranscoder/activity/MainActivity.java
+++ b/app/src/main/java/protect/videotranscoder/activity/MainActivity.java
@@ -626,12 +626,6 @@ public class MainActivity extends AppCompatActivity
             command.add("-an");
         }
 
-        if (container == MediaContainer.GIF)
-        {
-            command.add("-filter_complex");
-            command.add("fps=" + fps + ",split [o1] [o2];[o1] palettegen [p]; [o2] fifo [o3];[o3] [p] paletteuse");
-        }
-
         // Output file
         command.add(destinationFilePath);
 


### PR DESCRIPTION
GIF files only support 256 colors. Previously a pass over the input
video was taken to develop a good color palette before converting
to gif. However, it was found that on a recent FFmpeg version that
the palette generation step was taking a significant amount of
memory and time to complete. For non-trivial videos it was not
possible to create a gif.

This change removes the palette generation step. Instead, a default
palette that FFmpeg defines is used. This will likely
cause the color quality of the output gif to decrease, however
it should be much quicker to generate the gif.

If the quality of the generated gif files is not that great, here are some options
to improving the quality:
http://blog.pkh.me/p/21-high-quality-gif-with-ffmpeg.html

https://github.com/brarcher/video-transcoder/issues/67