### PR TITLE
Set the 'preset' setting for h264 to 'faster'

### DIFF
--- a/app/src/main/java/protect/videotranscoder/activity/MainActivity.java
+++ b/app/src/main/java/protect/videotranscoder/activity/MainActivity.java
@@ -680,6 +680,8 @@ public class MainActivity extends AppCompatActivity
                 command.add(videoBitrateK + "k");
             }
 
+            command.addAll(videoCodec.extraFfmpegArgs);
+
             // Frame size
             command.add("-s");
             command.add(resolution);
@@ -699,13 +701,7 @@ public class MainActivity extends AppCompatActivity
             command.add("-acodec");
             command.add(audioCodec.ffmpegName);
 
-            if (audioCodec == AudioCodec.VORBIS)
-            {
-                // The vorbis encode is experimental, and needs other
-                // flags to enable
-                command.add("-strict");
-                command.add("-2");
-            }
+            command.addAll(audioCodec.extraFfmpegArgs);
 
             // Sample rate
             command.add("-ar");

--- a/app/src/main/java/protect/videotranscoder/media/AudioCodec.java
+++ b/app/src/main/java/protect/videotranscoder/media/AudioCodec.java
@@ -11,19 +11,23 @@ import java.util.List;
  */
 public enum AudioCodec
 {
-    AAC("aac", Arrays.asList("1", "2")),
-    MP3("mp3", Arrays.asList("1", "2")),
-    OPUS("libopus", Arrays.asList("1", "2")),
-    VORBIS("vorbis", Collections.singletonList("2")),
-    NONE("none", Collections.EMPTY_LIST),
+    AAC("aac", Collections.EMPTY_LIST, Arrays.asList("1", "2")),
+    MP3("mp3", Collections.EMPTY_LIST, Arrays.asList("1", "2")),
+    OPUS("libopus", Collections.EMPTY_LIST, Arrays.asList("1", "2")),
+
+    // The vorbis encode is experimental, and needs other flags to enable
+    VORBIS("vorbis", Arrays.asList("-strict", "-2"), Collections.singletonList("2")),
+    NONE("none", Collections.EMPTY_LIST, Collections.EMPTY_LIST),
     ;
 
     public final String ffmpegName;
+    public final List<String> extraFfmpegArgs;
     public final List<String> supportedChannels;
 
-    AudioCodec(String ffmpegName, List<String> supportedChannels)
+    AudioCodec(String ffmpegName, List<String> extraFfmpegArgs, List<String> supportedChannels)
     {
         this.ffmpegName = ffmpegName;
+        this.extraFfmpegArgs = extraFfmpegArgs;
         this.supportedChannels = Collections.unmodifiableList(supportedChannels);
     }
 

--- a/app/src/main/java/protect/videotranscoder/media/VideoCodec.java
+++ b/app/src/main/java/protect/videotranscoder/media/VideoCodec.java
@@ -2,6 +2,10 @@ package protect.videotranscoder.media;
 
 import android.support.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import protect.videotranscoder.R;
 
 /**
@@ -9,21 +13,23 @@ import protect.videotranscoder.R;
  */
 public enum VideoCodec
 {
-    H264("h264", "H.264", R.string.codecSlowExcellent),
-    MPEG4("mpeg4", "MPEG-4", R.string.codecFastGood),
-    MPEG2("mpeg2video", "MPEG-2", R.string.codecFastOk),
-    MPEG1("mpeg1video", "MPEG-1", R.string.codecFastLow),
-    GIF("gif", "GIF", null),
+    H264("h264", "H.264", Collections.EMPTY_LIST, R.string.codecSlowExcellent),
+    MPEG4("mpeg4", "MPEG-4", Collections.EMPTY_LIST, R.string.codecFastGood),
+    MPEG2("mpeg2video", "MPEG-2", Collections.EMPTY_LIST, R.string.codecFastOk),
+    MPEG1("mpeg1video", "MPEG-1", Collections.EMPTY_LIST, R.string.codecFastLow),
+    GIF("gif", "GIF", Collections.EMPTY_LIST, null),
     ;
 
     public final String ffmpegName;
     public final String prettyName;
+    public final List<String> extraFfmpegArgs;
     public final Integer helperTextId;
 
-    VideoCodec(String ffmpegName, String prettyName, Integer helperTextId)
+    VideoCodec(String ffmpegName, String prettyName, List<String> extraFfmpegArgs, Integer helperTextId)
     {
         this.ffmpegName = ffmpegName;
         this.prettyName = prettyName;
+        this.extraFfmpegArgs = extraFfmpegArgs;
         this.helperTextId = helperTextId;
     }
 

--- a/app/src/main/java/protect/videotranscoder/media/VideoCodec.java
+++ b/app/src/main/java/protect/videotranscoder/media/VideoCodec.java
@@ -13,7 +13,11 @@ import protect.videotranscoder.R;
  */
 public enum VideoCodec
 {
-    H264("h264", "H.264", Collections.EMPTY_LIST, R.string.codecSlowExcellent),
+    // The 'preset' setting for h264 is changed from its default of 'medium'. The
+    // 'faster' setting reduces encoding times by ~73% while only reducing quality
+    // a near imperceptible amount. This seems like a good trade-off for encoding
+    // on a mobile devices where power usage is a concern.
+    H264("h264", "H.264", Arrays.asList("-preset", "faster"), R.string.codecSlowExcellent),
     MPEG4("mpeg4", "MPEG-4", Collections.EMPTY_LIST, R.string.codecFastGood),
     MPEG2("mpeg2video", "MPEG-2", Collections.EMPTY_LIST, R.string.codecFastOk),
     MPEG1("mpeg1video", "MPEG-1", Collections.EMPTY_LIST, R.string.codecFastLow),


### PR DESCRIPTION
An article examined the time/quality trade-off for h264 and
concluded that the best default option was 'faster'. Compared
to 'medium', which is the default for FFmpeg, 'faster' reduced
encoding times ~73% and reduced the quality in a likely
imperceptible manner.
    
This sounds like a good trade-off generally, especially for a
mobile device where power usage is a concern. This commit
changes the 'preset' setting to 'faster'.
    
The article was found here:
https://streaminglearningcenter.com/blogs/saving-encoding-adjust-encoding-configuration-increase-capacity.html

This closes https://github.com/brarcher/video-transcoder/issues/119