### PR TITLE
Lower the min sdk to 19

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "protect.videoeditor"
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 27
         versionCode 11
         versionName "0.11"


### PR DESCRIPTION
The min sdk was increased to 21 because JobService was being used.
Since, that has been removed, so the app should work on sdk 19.
The sdk could be lower yet, as the app did compile on sdk 16. However,
unless someone is interested in trying that out on a device, sdk 19
is fine for now.